### PR TITLE
Modify CMakeLists to export cereal to openMVG-targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required (VERSION 2.6.2)
 project (cereal)
 
 option(SKIP_PORTABILITY_TEST "Skip portability (32 bit) tests" OFF)
-if(NOT CMAKE_VERSION VERSION_LESS 3.0) # installing cereal requires INTERFACE lib
-    option(JUST_INSTALL_CEREAL "Don't do anything besides installing the library" OFF)
-endif()
 
 option(THREAD_SAFE "Use mutexes to ensure thread safety" OFF)
 if(THREAD_SAFE)
@@ -36,31 +33,11 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.0)
     add_library(cereal INTERFACE)
     target_include_directories(cereal INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:include/openMVG_dependencies/cereal/include>
     )
-    install(TARGETS cereal EXPORT cereal
+  install(TARGETS cereal EXPORT openMVG-targets
         DESTINATION lib) # ignored
-    install(EXPORT cereal FILE cereal-config.cmake
-        DESTINATION share/cmake/cereal)
-    install(DIRECTORY include/cereal DESTINATION include)
+    #install(EXPORT cereal FILE cereal-config.cmake
+        #DESTINATION share/cmake/cereal)
+    #install(DIRECTORY include/cereal DESTINATION include)
 endif()
-
-if(JUST_INSTALL_CEREAL)
-    return()
-endif()
-
-include_directories(./include)
-
-# Boost serialization for performance sandbox
-find_package(Boost COMPONENTS serialization)
-
-if(Boost_FOUND)
-  include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-endif(Boost_FOUND)
-  
-enable_testing()
-add_subdirectory(unittests)
-
-add_subdirectory(sandbox)
-
-add_subdirectory(doc)


### PR DESCRIPTION
It is better to export cereal and link it to other modules.
I think we should not manually setting include path for cereal from outside.